### PR TITLE
Remove chrome version of e2espec

### DIFF
--- a/e2espec.yml
+++ b/e2espec.yml
@@ -7,7 +7,7 @@ phases:
       - curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
       - echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list
       - apt-get -y update
-      - apt-get -y install google-chrome-stable=76.0.3809.100-1
+      - apt-get -y install google-chrome-stable
       - npm install --unsafe-perm -g @angular/cli@8.3.3
       - npm install
   build:


### PR DESCRIPTION
```
Running command apt-get -y install google-chrome-stable=76.0.3809.100-1 
Reading package lists... 
Building dependency tree... 
Reading state information... 
E: Version '76.0.3809.100-1' for 'google-chrome-stable' was not found 
```